### PR TITLE
Reword `send_message` description

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,9 +43,9 @@ require 'saharspec/matchers/send_message'
 it {
   expect { fetcher }.to send_message(Net::HTTP, :get).with('http://google.com').returning('not this time')
 }
-# after + its_call
+# after + its_block
 subject { fetcher }
-its_call { is_expected.to send_message(Net::HTTP, :get).with('http://google.com').returning('not this time') }
+its_block { is_expected.to send_message(Net::HTTP, :get).with('http://google.com').returning('not this time') }
 ```
 
 Note: there is [reasons](https://github.com/rspec/rspec-expectations/issues/934) why it is not in rspec-mocks, though, not very persuative for

--- a/lib/saharspec/matchers/send_message.rb
+++ b/lib/saharspec/matchers/send_message.rb
@@ -68,7 +68,7 @@ module Saharspec
       end
 
       def description
-        format('to send %p.%s', @target, @method)
+        format('send %p.%s', @target, @method)
       end
 
       def failure_message


### PR DESCRIPTION
Consider the following snippet:

``` rb
# frozen_string_literal: true

require 'bundler/inline'

gemfile do
  source 'https://rubygems.org'

  gem 'rspec', '= 3.8.0', require: 'rspec/autorun'
  gem 'saharspec', '= 0.0.5'
end

class Example
  def call(arg)
    arg.do_work
  end
end

RSpec.configure do |config|
  config.formatter = :documentation
end

RSpec.describe Example do
  let(:example) { described_class.new }

  describe '#call' do
    subject { example.call(arg) }

    let(:arg) { spy('arg') }

    its_block { is_expected.to send_message(arg, :do_work) }
  end
end
```

When run, it produces a rather awkward message that doesn't read as valid English ("should to send"):

``` text
Example
  #call
    as block
      should to send #<Double "arg">.do_work
```

This PR removes "to" and fixes what seems to be a stale example in README.