### PR TITLE
Proper lint for rubocop-rspec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Saharspec history
 
+## 0.0.9 -- 2022-20-04
+
+* Properly lint RSpec specs using `its_block`/`its_call`/`its_map` with `rubocop-rspec` >= 2.0 ([@ka8725][])
+
 ## 0.0.8 -- 2020-10-10
 
 * Better `dont` failure message (just use underlying matchers `failure_message_when_negated`)

--- a/README.md
+++ b/README.md
@@ -250,6 +250,16 @@ describe '#delete_at' do
 end
 ```
 
+### Linting with RuboCop RSpec
+
+`rubocop-rspec` fails to properly detect RSpec constructs that Saharspec defines (`its_call`, `its_block`, `its_map`).
+Make sure to use `rubocop-rspec` 2.0 or newer and add the following to your `.rubocop.yml`:
+
+```yaml
+inherit_gem:
+  saharaspec: config/rubocop-rspec.yml
+```
+
 ## State & future
 
 I use all of the components of the library on daily basis. Probably, I will extend it with other

--- a/config/rubocop-rspec.yml
+++ b/config/rubocop-rspec.yml
@@ -1,0 +1,13 @@
+RSpec:
+  Language:
+    Includes:
+      Examples:
+        - its_block
+        - its_call
+        - its_map
+        - fits_block
+        - fits_call
+        - fits_map
+        - xits_block
+        - xits_call
+        - xits_map


### PR DESCRIPTION
The default configuration of Rubocop RSpec fails to detect constructions `its_block`/`its_call`/`its_map` defined by Saharaspec.

This PR fixes the issue.

Consider the following example:

```ruby
# cat spec/example_spec.rb
describe 'Saharaspec' do
  context 'text' do
    subject { 'x' }

    its_block { is_expected.to eq 'x' }
  end
end
```

As default `rubocop` command fails as this:

```
spec/example_spec.rb:2:3: C: RSpec/EmptyExampleGroup: Empty example group detected.
  context 'text' do
  ^^^^^^^^^^^^^^
```

Install the fix locally updating Gemfile as follows: 

```ruby
gem 'saharspec', require: false, path: '<path_to_local_dir>/saharspec'
```

Add these lines to `.rubocop.yml` of you project:

```yml
inherit_gem:
  saharspec: config/rubocop-rspec.yml
```

And now Rubocop has no complains.

This is a follow up on this issue https://github.com/rubocop/rubocop-rspec/issues/975