### PR TITLE
Update rubocop config for proper linting

### DIFF
--- a/config/rubocop-rspec.yml
+++ b/config/rubocop-rspec.yml
@@ -1,13 +1,15 @@
 RSpec:
   Language:
-    Includes:
-      Examples:
+    Examples:
+      Regular:
         - its_block
         - its_call
         - its_map
-        - fits_block
-        - fits_call
-        - fits_map
+      Skipped:
         - xits_block
         - xits_call
         - xits_map
+      Focused:
+        - fits_block
+        - fits_call
+        - fits_map


### PR DESCRIPTION
FIx [rubocop-rspec#1290](https://github.com/rubocop/rubocop-rspec/pull/1290).
Following discussion in [rubocop-rspec#1291](https://github.com/rubocop/rubocop-rspec/pull/1291).

This PR aims to provide a better rubocop configuration to handle implicit subjects, but also add the following drawback:

```ruby
its_call(123)         { is_expected.to send_message(Foo, :call).once }
its_call("203000592") { is_expected.to send_message(Foo, :call).once }
```
```
RSpec/RepeatedExample: Don't repeat examples within an example group. (https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/RepeatedExample)
  its_call(123)         { is_expected.to send_message(Foo, :call).once }
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
RSpec/RepeatedExample: Don't repeat examples within an example group. (https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/RepeatedExample)
  its_call("203000592") { is_expected.to send_message(Foo, :call).once }
```

These tests are detected as duplicates because of their similar block content.
Their distinct arguments are interpreted as a description.

This can be circumvented by enhancing the tests but that may not be suitable for every scenario:

```ruby
its_call(123)         { is_expected.to send_message(Foo, :call).once.with(123) }
its_call("203000592") { is_expected.to send_message(Foo, :call).once.with("203000592") }
```


