### PR TITLE
Require core

### DIFF
--- a/lib/saharspec.rb
+++ b/lib/saharspec.rb
@@ -7,6 +7,7 @@
 module Saharspec
 end
 
+require 'rspec/core'
 require_relative 'saharspec/its'
 require_relative 'saharspec/matchers'
 require_relative 'saharspec/util'

--- a/lib/saharspec.rb
+++ b/lib/saharspec.rb
@@ -7,7 +7,6 @@
 module Saharspec
 end
 
-require 'rspec/core'
 require_relative 'saharspec/its'
 require_relative 'saharspec/matchers'
 require_relative 'saharspec/util'

--- a/lib/saharspec/its/block.rb
+++ b/lib/saharspec/its/block.rb
@@ -52,11 +52,8 @@ module Saharspec
 end
 
 unless defined?(RSpec)
-  if Gem::Specification.all_names.include?('rspec')
-    raise 'RSpec is installed but not yet loaded'
-  end
-
-  raise 'RSpec is not present in the current environment'
+  raise 'RSpec is not present in the current environment, check that `rspec` ' \
+        'is present in your Gemfile and is in the same group as `saharspec`' \
 end
 
 RSpec.configure do |rspec|

--- a/lib/saharspec/its/block.rb
+++ b/lib/saharspec/its/block.rb
@@ -51,6 +51,14 @@ module Saharspec
   end
 end
 
+unless defined?(RSpec)
+  if Gem::Specification.all_names.include?('rspec')
+    raise 'RSpec is installed but not yet loaded'
+  end
+
+  raise 'RSpec is not present in the current environment'
+end
+
 RSpec.configure do |rspec|
   rspec.extend Saharspec::Its::Block
   rspec.backtrace_exclusion_patterns << %r{/lib/saharspec/its/block}

--- a/lib/saharspec/its/call.rb
+++ b/lib/saharspec/its/call.rb
@@ -47,11 +47,8 @@ module Saharspec
 end
 
 unless defined?(RSpec)
-  if Gem::Specification.all_names.include?('rspec')
-    raise 'RSpec is installed but not yet loaded'
-  end
-
-  raise 'RSpec is not present in the current environment'
+  raise 'RSpec is not present in the current environment, check that `rspec` ' \
+        'is present in your Gemfile and is in the same group as `saharspec`' \
 end
 
 RSpec.configure do |rspec|

--- a/lib/saharspec/its/call.rb
+++ b/lib/saharspec/its/call.rb
@@ -46,6 +46,14 @@ module Saharspec
   end
 end
 
+unless defined?(RSpec)
+  if Gem::Specification.all_names.include?('rspec')
+    raise 'RSpec is installed but not yet loaded'
+  end
+
+  raise 'RSpec is not present in the current environment'
+end
+
 RSpec.configure do |rspec|
   rspec.extend Saharspec::Its::Call
   rspec.backtrace_exclusion_patterns << %r{/lib/saharspec/its/call}

--- a/lib/saharspec/its/map.rb
+++ b/lib/saharspec/its/map.rb
@@ -32,7 +32,7 @@ module Saharspec
       # @param block [Proc] The test itself. Inside it, `is_expected` (or `are_expected`) is related to result
       #  of `map`ping the subject.
       #
-      def its_map(attribute, *options, &) # rubocop:disable Metrics/AbcSize, Metrics/MethodLength, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+      def its_map(attribute, *options, &block) # rubocop:disable Metrics/AbcSize, Metrics/MethodLength, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
         # rubocop:disable Lint/NestedMethodDefinition
         # TODO: better desciption for different cases
         describe("map(&:#{attribute})") do
@@ -61,7 +61,7 @@ module Saharspec
 
           options << {} unless options.last.is_a?(Hash)
 
-          example(nil, *options, &)
+          example(nil, *options, &block)
         end
         # rubocop:enable Lint/NestedMethodDefinition
       end

--- a/lib/saharspec/its/map.rb
+++ b/lib/saharspec/its/map.rb
@@ -69,6 +69,14 @@ module Saharspec
   end
 end
 
+unless defined?(RSpec)
+  if Gem::Specification.all_names.include?('rspec')
+    raise 'RSpec is installed but not yet loaded'
+  end
+
+  raise 'RSpec is not present in the current environment'
+end
+
 RSpec.configure do |rspec|
   rspec.extend Saharspec::Its::Map
   rspec.backtrace_exclusion_patterns << %r{/lib/saharspec/its/map}

--- a/lib/saharspec/its/map.rb
+++ b/lib/saharspec/its/map.rb
@@ -32,7 +32,7 @@ module Saharspec
       # @param block [Proc] The test itself. Inside it, `is_expected` (or `are_expected`) is related to result
       #  of `map`ping the subject.
       #
-      def its_map(attribute, *options, &block) # rubocop:disable Metrics/AbcSize, Metrics/MethodLength, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+      def its_map(attribute, *options, &) # rubocop:disable Metrics/AbcSize, Metrics/MethodLength, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
         # rubocop:disable Lint/NestedMethodDefinition
         # TODO: better desciption for different cases
         describe("map(&:#{attribute})") do
@@ -61,7 +61,7 @@ module Saharspec
 
           options << {} unless options.last.is_a?(Hash)
 
-          example(nil, *options, &block)
+          example(nil, *options, &)
         end
         # rubocop:enable Lint/NestedMethodDefinition
       end
@@ -70,11 +70,8 @@ module Saharspec
 end
 
 unless defined?(RSpec)
-  if Gem::Specification.all_names.include?('rspec')
-    raise 'RSpec is installed but not yet loaded'
-  end
-
-  raise 'RSpec is not present in the current environment'
+  raise 'RSpec is not present in the current environment, check that `rspec` ' \
+        'is present in your Gemfile and is in the same group as `saharspec`' \
 end
 
 RSpec.configure do |rspec|

--- a/spec/saharspec/matchers/send_message_spec.rb
+++ b/spec/saharspec/matchers/send_message_spec.rb
@@ -91,7 +91,7 @@ RSpec.describe :send_message do
         it {
           require 'saharspec/matchers/dont'
 
-          expect { obj1.meth}
+          expect { obj1.meth }
             .to send_message(obj1, :meth)
             .and dont.send_message(obj2, :meth)
         }


### PR DESCRIPTION
Hey. Not sure if that's the actual solution but seems to be logical and also works.

Versions:
- `ruby 3.1.2p20 (2022-04-12 revision 4491bb740a) [arm64-darwin21]`
- `Rails 7.0.3.1`

I have a project in which I decided to use this newfound wonderful gem. But after installing it neither rails commands such as `console` or `server` stopped working in the environments I required it in, however tests ran splendidly.
The error I got was:
```
undefined method configure for RSpec:Module.
```

Here is a more detailed backtrace:
```
/Users/barseek/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/saharspec-0.0.9/lib/saharspec/its/map.rb:72:in `<main>': undefined method `configure' for RSpec:Module (NoMethodError)

RSpec.configure do |rspec|
     ^^^^^^^^^^
        from /Users/barseek/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/saharspec-0.0.9/lib/saharspec/its.rb:35:in `require_relative'
        from /Users/barseek/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/saharspec-0.0.9/lib/saharspec/its.rb:35:in `<main>'
        from /Users/barseek/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/saharspec-0.0.9/lib/saharspec.rb:10:in `require_relative'
        from /Users/barseek/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/saharspec-0.0.9/lib/saharspec.rb:10:in `<main>'
        from /Users/barseek/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/bootsnap-1.13.0/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:32:in `require'
        from /Users/barseek/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/bootsnap-1.13.0/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:32:in `require'
        from /Users/barseek/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/runtime.rb:60:in `block (2 levels) in require'
        from /Users/barseek/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/runtime.rb:55:in `each'
        from /Users/barseek/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/runtime.rb:55:in `block in require'
        from /Users/barseek/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/runtime.rb:44:in `each'
        from /Users/barseek/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/runtime.rb:44:in `require'
        from /Users/barseek/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler.rb:176:in `require'
        from /Users/barseek/src/some_cool/app_name/config/application.rb:19:in `<main>'
        from /Users/barseek/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/bootsnap-1.13.0/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:32:in `require'
        from /Users/barseek/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/bootsnap-1.13.0/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:32:in `require'
        from /Users/barseek/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/railties-7.0.3.1/lib/rails/commands/server/server_command.rb:137:in `block in perform'
        from <internal:kernel>:90:in `tap'
        from /Users/barseek/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/railties-7.0.3.1/lib/rails/commands/server/server_command.rb:134:in `perform'
        from /Users/barseek/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/thor-1.2.1/lib/thor/command.rb:27:in `run'
        from /Users/barseek/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/thor-1.2.1/lib/thor/invocation.rb:127:in `invoke_command'
        from /Users/barseek/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/thor-1.2.1/lib/thor.rb:392:in `dispatch'
        from /Users/barseek/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/railties-7.0.3.1/lib/rails/command/base.rb:87:in `perform'
        from /Users/barseek/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/railties-7.0.3.1/lib/rails/command.rb:48:in `invoke'
        from /Users/barseek/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/railties-7.0.3.1/lib/rails/commands.rb:18:in `<main>'
        from /Users/barseek/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/bootsnap-1.13.0/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:32:in `require'
        from /Users/barseek/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/bootsnap-1.13.0/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:32:in `require'
        from bin/rails:4:in `<main>'
```
        
I actually couldn't replicate that in a brand new environment, so maybe the problem is somewhere in my envs or compatibilities, but this seems to solve it. Tell me what you think, maybe I can provide more information for you.