### PR TITLE
The gem should not be required

### DIFF
--- a/lib/saharspec.rb
+++ b/lib/saharspec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
-defined?(RSpec) or
-  fail 'RSpec is not present in the current environment, check that `rspec` ' \
-        'is present in your Gemfile and is in the same group as `saharspec`' \
+require 'rspec/core'
 
 # Umbrella module for all Saharspec RSpec DRY-ing features.
 #


### PR DESCRIPTION
If the gem is required (as by default), it shows this:

```
RAILS_ENV=test rails db:migrate --trace
rails aborted!
NoMethodError: undefined method `configure' for RSpec:Module
/Users/ka8725/.rbenv/versions/3.2.1/lib/ruby/gems/3.2.0/gems/saharspec-0.0.10/lib/saharspec/its/map.rb:72:in `<top (required)>'
/Users/ka8725/.rbenv/versions/3.2.1/lib/ruby/gems/3.2.0/gems/saharspec-0.0.10/lib/saharspec/its.rb:35:in `require_relative'
/Users/ka8725/.rbenv/versions/3.2.1/lib/ruby/gems/3.2.0/gems/saharspec-0.0.10/lib/saharspec/its.rb:35:in `<top (required)>'
/Users/ka8725/.rbenv/versions/3.2.1/lib/ruby/gems/3.2.0/gems/saharspec-0.0.10/lib/saharspec.rb:14:in `require_relative'
/Users/ka8725/.rbenv/versions/3.2.1/lib/ruby/gems/3.2.0/gems/saharspec-0.0.10/lib/saharspec.rb:14:in `<top (required)>'
/Users/ka8725/.rbenv/versions/3.2.1/lib/ruby/gems/3.2.0/gems/bundler-2.4.1/lib/bundler/runtime.rb:60:in `require'
/Users/ka8725/.rbenv/versions/3.2.1/lib/ruby/gems/3.2.0/gems/bundler-2.4.1/lib/bundler/runtime.rb:60:in `block (2 levels) in require'
/Users/ka8725/.rbenv/versions/3.2.1/lib/ruby/gems/3.2.0/gems/bundler-2.4.1/lib/bundler/runtime.rb:55:in `each'
/Users/ka8725/.rbenv/versions/3.2.1/lib/ruby/gems/3.2.0/gems/bundler-2.4.1/lib/bundler/runtime.rb:55:in `block in require'
/Users/ka8725/.rbenv/versions/3.2.1/lib/ruby/gems/3.2.0/gems/bundler-2.4.1/lib/bundler/runtime.rb:44:in `each'
/Users/ka8725/.rbenv/versions/3.2.1/lib/ruby/gems/3.2.0/gems/bundler-2.4.1/lib/bundler/runtime.rb:44:in `require'
/Users/ka8725/.rbenv/versions/3.2.1/lib/ruby/gems/3.2.0/gems/bundler-2.4.1/lib/bundler.rb:195:in `require'
/Users/ka8725/projects/meze/mezuka/config/application.rb:17:in `<top (required)>'
/Users/ka8725/projects/meze/mezuka/Rakefile:6:in `require'
/Users/ka8725/projects/meze/mezuka/Rakefile:6:in `<top (required)>'
/Users/ka8725/.rbenv/versions/3.2.1/lib/ruby/gems/3.2.0/gems/rake-13.0.6/lib/rake/rake_module.rb:29:in `load'
/Users/ka8725/.rbenv/versions/3.2.1/lib/ruby/gems/3.2.0/gems/rake-13.0.6/lib/rake/rake_module.rb:29:in `load_rakefile'
/Users/ka8725/.rbenv/versions/3.2.1/lib/ruby/gems/3.2.0/gems/rake-13.0.6/lib/rake/application.rb:710:in `raw_load_rakefile'
/Users/ka8725/.rbenv/versions/3.2.1/lib/ruby/gems/3.2.0/gems/rake-13.0.6/lib/rake/application.rb:104:in `block in load_rakefile'
/Users/ka8725/.rbenv/versions/3.2.1/lib/ruby/gems/3.2.0/gems/rake-13.0.6/lib/rake/application.rb:186:in `standard_exception_handling'
/Users/ka8725/.rbenv/versions/3.2.1/lib/ruby/gems/3.2.0/gems/rake-13.0.6/lib/rake/application.rb:103:in `load_rakefile'
/Users/ka8725/.rbenv/versions/3.2.1/lib/ruby/gems/3.2.0/gems/railties-7.0.4/lib/rails/commands/rake/rake_command.rb:20:in `block in perform'
/Users/ka8725/.rbenv/versions/3.2.1/lib/ruby/gems/3.2.0/gems/rake-13.0.6/lib/rake/rake_module.rb:59:in `with_application'
/Users/ka8725/.rbenv/versions/3.2.1/lib/ruby/gems/3.2.0/gems/railties-7.0.4/lib/rails/commands/rake/rake_command.rb:18:in `perform'
/Users/ka8725/.rbenv/versions/3.2.1/lib/ruby/gems/3.2.0/gems/railties-7.0.4/lib/rails/command.rb:51:in `invoke'
/Users/ka8725/.rbenv/versions/3.2.1/lib/ruby/gems/3.2.0/gems/railties-7.0.4/lib/rails/commands.rb:18:in `<top (required)>'
```